### PR TITLE
Fixed Inertia Head component demo

### DIFF
--- a/resources/js/Pages/Class/Search.vue
+++ b/resources/js/Pages/Class/Search.vue
@@ -20,7 +20,7 @@ new class {
 </php>
 
 <template>
-  <Head title="Home" />
+  <Head title="Search" />
   <div class="p-6 max-w-4xl mx-auto">
     <div class='mb-6'>
       <div class="flex gap-2">

--- a/resources/js/Pages/Search.vue
+++ b/resources/js/Pages/Search.vue
@@ -17,7 +17,7 @@ expose(favorite: function(Podcast $podcast) {
 </php>
 
 <template>
-  <Head title="Home" />
+  <Head title="Search" />
   <div class="p-6 max-w-4xl mx-auto">
     <div class='mb-6'>
       <div class="flex gap-2">

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -10,7 +10,7 @@ import fusion from '@fusion/vue/vue';
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
-  title: (title) => `Fusion`,
+  title: (title) => `Fusion ${title}`,
   resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
 
   setup({el, App, props, plugin}) {


### PR DESCRIPTION
This fixes the following problem.

---

The inertia head component is currently not working as expected.

In order to make it work, we have to update `resources/js/app.js`.

```js
createInertiaApp({
  title: (title) => `Fusion ${title}`,
});
```

Also I update the `<Head title="Search" />` parts, because the title was set to "Home" before.

Now the browser tab shows "Fusion - Home" like expected.